### PR TITLE
Feature 10 Autogenerate number private to employee

### DIFF
--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -1,3 +1,15 @@
+# frozen_string_literal: true
+
 class Employee < ApplicationRecord
   belongs_to :company_branch
+
+  before_create :generate_private_number
+
+  validates :private_number, uniqueness: true
+
+  private
+
+  def generate_private_number
+    self.private_number = SecureRandom.hex(3).upcase
+  end
 end

--- a/db/migrate/20210418183243_change_employee_private_number_type.rb
+++ b/db/migrate/20210418183243_change_employee_private_number_type.rb
@@ -1,0 +1,6 @@
+class ChangeEmployeePrivateNumberType < ActiveRecord::Migration[6.1]
+  def change
+    change_column :employees, :private_number, :string
+    add_index :employees, :private_number, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_16_143211) do
+ActiveRecord::Schema.define(version: 2021_04_18_183243) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,12 +37,13 @@ ActiveRecord::Schema.define(version: 2021_04_16_143211) do
     t.string "name"
     t.string "email"
     t.string "position"
-    t.integer "private_number"
+    t.string "private_number"
     t.bigint "company_branch_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "state", default: true
     t.index ["company_branch_id"], name: "index_employees_on_company_branch_id"
+    t.index ["private_number"], name: "index_employees_on_private_number", unique: true
   end
 
   add_foreign_key "company_branches", "admins"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,7 +28,6 @@ CompanyBranch.all.each do |company_branch|
     name: "Employee#{number}",
     email: "email#{number}",
     position: "position#{number}",
-    private_number: number,
     company_branch_id: company_branch.id
   )
 end

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -1,5 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe Employee, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:admin) do
+    Admin.create!(email: 'admin@example.com', password: 'password', password_confirmation: 'password')
+  end
+  let(:company_branch) do
+    CompanyBranch.create!(name:'Foo', address:'Foo', admin_id: admin.id )
+  end
+  describe '#generate_private_number' do
+    context 'Before employee is created' do
+      it 'generate a private number' do
+        employee = Employee.new(company_branch_id: company_branch.id)
+        expect(employee.private_number).to be_nil
+        employee.save!
+        expect(employee.private_number).to be_present
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Description

- Prepare data to private num to be unique and alphanumeric
- Autogenerate private num to employee on create
- Include test
 
 # Testing

- rails db:migrate
- rails db:seed:replant  
- Employees must have an Alphanuneric private number.

![Image 2021-04-19 at 11 17 51 a m](https://user-images.githubusercontent.com/11895273/115212683-0e300780-a101-11eb-978c-9f0391d66375.jpg)

