### PR TITLE
Feature#19 disabling employees

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'turbolinks', '~> 5'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 # Windows Directory Monitor (WDM) is a library which can be used to monitor directories for changes.
-gem 'wdm', '>= 0.1.0' if Gem.win_platform?
+gem 'wdm', '>= 0.1.0', platforms: %i[mingw mswin x64_mingw jruby]
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker', '~> 5.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,6 +317,8 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2021.1)
+      tzinfo (>= 1.0.0)
     unicode-display_width (2.0.0)
     victor (0.2.8)
     virtus (1.0.5)
@@ -390,5 +392,13 @@ DEPENDENCIES
 RUBY VERSION
    ruby 2.7.2p137
 
+BUNDLED WITH
+   2.2.16
+BUNDLED WITH
+   2.2.16
+   ruby 2.7.2p137
+
+BUNDLED WITH
+   2.2.16
 BUNDLED WITH
    2.2.16

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -1,9 +1,10 @@
 class EmployeesController < ApplicationController
   before_action :set_current_branch
-  before_action :set_employee, only: %i[ show edit update destroy ]
-
+  before_action :set_employee, only: %i[ show edit update destroy change_state]
+  
   def index
     @pagy, @employees = pagy(@company_branch.employees, items: 10)
+    @employees = @company_branch.employees.order(state: :desc)
   end
 
   def show; end
@@ -31,9 +32,18 @@ class EmployeesController < ApplicationController
     end
   end
 
+  def change_state
+    if @employee.update( state: params[:state] == "true")
+      flash[:success] = %{Employee "#{@employee.name}" state updated}
+    else
+      flash[:error] = %{Employee could not be updated}
+    end
+    redirect_to company_branch_employees_path(@company_branch)
+  end
+
   private
   def employee_params
-    params.require(:employee).permit(:email, :name, :position, :employee_number, :private_number)
+    params.require(:employee).permit(:email, :name, :position, :employee_number, :private_number, :state)
   end
 
   def set_employee

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -33,11 +33,13 @@ class EmployeesController < ApplicationController
   end
 
   def change_state
-    if @employee.update( state: params[:state] == "true")
-      flash[:success] = %{Employee "#{@employee.name}" state updated}
-    else
-      flash[:error] = %{Employee could not be updated}
-    end
+    @employee.toggle!(:state)
+    # if @employee.update(state: params[:state] == 'true')
+    #   @employee.toggle!(:state)
+    #   flash[:success] = %{Employee "#{@employee.name}" state updated}
+    # else
+    #   flash[:error] = %{Employee could not be updated}
+    # end
     redirect_to company_branch_employees_path(@company_branch)
   end
 

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -33,13 +33,11 @@ class EmployeesController < ApplicationController
   end
 
   def change_state
-    @employee.toggle!(:state)
-    # if @employee.update(state: params[:state] == 'true')
-    #   @employee.toggle!(:state)
-    #   flash[:success] = %{Employee "#{@employee.name}" state updated}
-    # else
-    #   flash[:error] = %{Employee could not be updated}
-    # end
+    if @employee.toggle(:state).errors.empty?
+      flash[:success] = %(Employee "#{@employee.name}" has been #{@employee.state ? 'enabled' : 'disabled'})
+    else
+      flash[:error] = %(Employee couldn't be updated)
+    end
     redirect_to company_branch_employees_path(@company_branch)
   end
 

--- a/app/views/employees/_form.html.erb
+++ b/app/views/employees/_form.html.erb
@@ -9,6 +9,9 @@
   <div class="field">
     <%= form.text_field :position, placeholder:"Position" %>
   </div>
+   <div class="field mt-4">
+    <%= form.label employee.state %>
+  </div>
   <div class="actions d-flex justify-content-center mt-4">
     <%= form.submit "Save" , class: 'btn btn-primary' %>
   </div>

--- a/app/views/employees/index.html.erb
+++ b/app/views/employees/index.html.erb
@@ -10,6 +10,7 @@
           <th scope="col">Email</th>
           <th scope="col">Position</th>
           <th scope="col">Private number</th>
+          <th scope="col">State</th>
           <th colspan="3"></th>
         </tr>
       </thead>
@@ -22,11 +23,16 @@
             <td><%= employee.email %></td>
             <td><%= employee.position %></td>
             <td><%= employee.private_number %></td>
+            <td><%= employee.state %></td>            
+            <td>
+              <%= link_to 'Switch', switch_state_employee_company_branch_employee_path(@company_branch, employee, state: !employee.state),
+              method: :patch, data: { confirm: 'Are you sure?' }, class:"btn btn-outline-warning" %>
+            </td>
             <td><%= link_to 'Show', company_branch_employee_path(@company_branch, employee),
-            class: "btn btn-outline-secondary" %>
+              class: "btn btn-outline-secondary" %>
             </td>
             <td><%= link_to 'Edit', edit_company_branch_employee_path(@company_branch, employee),
-            class: "btn btn-outline-primary" %>
+              class: "btn btn-outline-primary" %>
             </td>
           </tr>
         <% end %>

--- a/app/views/employees/index.html.erb
+++ b/app/views/employees/index.html.erb
@@ -23,11 +23,12 @@
             <td><%= employee.email %></td>
             <td><%= employee.position %></td>
             <td><%= employee.private_number %></td>
-            <td><%= employee.state %></td>            
-            <td>
-              <%= link_to 'Switch', switch_state_employee_company_branch_employee_path(@company_branch, employee, state: !employee.state),
-              method: :patch, data: { confirm: 'Are you sure?' }, class:"btn btn-outline-warning" %>
-            </td>
+            <td><%= employee.state %></td> 
+            <td class="employee-<%= employee.id %>">
+              <%= link_to "#{ employee.state ? 'Enabled' : 'Disabled' }", 
+              switch_state_employee_company_branch_employee_path(@company_branch, employee), 
+              method: :patch, remote: :true, class: "btn btn-xs btn-#{ employee.state ? 'success' : 'warning' }"  %>
+            </td>           
             <td><%= link_to 'Show', company_branch_employee_path(@company_branch, employee),
               class: "btn btn-outline-secondary" %>
             </td>

--- a/app/views/employees/index.html.erb
+++ b/app/views/employees/index.html.erb
@@ -27,7 +27,7 @@
             <td class="employee-<%= employee.id %>">
               <%= link_to "#{ employee.state ? 'Enabled' : 'Disabled' }", 
               switch_state_employee_company_branch_employee_path(@company_branch, employee), 
-              method: :patch, remote: :true, class: "btn btn-xs btn-#{ employee.state ? 'success' : 'warning' }"  %>
+              method: :patch, remote: :true, class: "btn btn-xs btn-outline-#{ employee.state ? 'success' : 'warning' }"  %>
             </td>           
             <td><%= link_to 'Show', company_branch_employee_path(@company_branch, employee),
               class: "btn btn-outline-secondary" %>

--- a/app/views/employees/show.html.erb
+++ b/app/views/employees/show.html.erb
@@ -25,6 +25,9 @@
 
             <dt class="col-6"><strong>Company branches:</strong></dt>
             <dd class="col-6"><%= @employee.company_branch_id %></dd>
+
+            <dt class="col-6"><strong>State:</strong></dt>
+            <dd class="col-6"><%= @employee.state %></dd>
           </dl>
         </div>
       </div>

--- a/app/views/employees/toggle_enabled_status.js.erb
+++ b/app/views/employees/toggle_enabled_status.js.erb
@@ -1,0 +1,12 @@
+<% if @employee.state%>
+    $(".employee-<%= @employee.id %> > a")
+    .html('Enabled')
+    .removeClass('btn-warning')
+    .addClass('btn-success')
+<% else %>
+    $(".employee-<%= @employee.id %> > a")
+    .html('Disabled')
+    .removeClass('btn-success')
+    .addClass('btn-warning')
+<% end %>
+$("#employee-status-<%= @employee.id %>").html("<%= @employee.state %>")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,9 @@ Rails.application.routes.draw do
 
   scope :admins do
     resources :company_branches do
-      resources :employees
+      resources :employees do
+        patch 'change_state', as: 'switch_state_employee', on: :member
+      end
     end
   end
   root to: 'company_branches#index'


### PR DESCRIPTION
# Description
Employees can change there state:
- Through an input you can disable and enable an employees status. This was implemented to know an employees current activity status. You can visualize the state from the employees table and in its own show view.
 # Testing
After cloning the repository run on the terminal in the repository directory:
```
yarn install
bundle install
rails db:setup
rails db:seed
rails server
```
Enter the URL (e.g.: http://127.0.0.1:3000) that rails server is listening on in your navigator.
User: admin@example.com
Password: password
Press the show button of any company branch.
Now you can manage your employees..

# Screenshots

### Walkthrough

![employee_enable_button](https://user-images.githubusercontent.com/47857206/116595826-59a89980-a8e9-11eb-885c-58f8f9924975.gif)
